### PR TITLE
fix(infra): stabilize test workflow on WSL and Linux environments

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -13,6 +13,8 @@ const PUBLIC_ERRORS = [
   NotFoundError,
 ];
 
+export { exceptionHandlers };
+
 function onNoMatchHandler(request, response) {
   const publicError = new MethodNotAllowedError();
   return response.status(publicError.statusCode).json(publicError);
@@ -37,5 +39,3 @@ const exceptionHandlers = {
   onNoMatch: onNoMatchHandler,
   onError: onErrorHandler,
 };
-
-export { exceptionHandlers };

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -4,7 +4,7 @@ import {
   ServiceError,
   ValidationError,
   NotFoundError,
-} from "infra/errors";
+} from "infra/errors.js";
 
 const PUBLIC_ERRORS = [
   ValidationError,

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,5 @@
 import { Client } from "pg";
-import { ServiceError } from "infra/errors";
+import { ServiceError } from "infra/errors.js";
 
 async function query(queryObject) {
   let client;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,6 +1,8 @@
 import { Client } from "pg";
 import { ServiceError } from "infra/errors.js";
 
+export { query, getNewClient };
+
 async function query(queryObject) {
   let client;
 
@@ -44,5 +46,3 @@ async function getNewClient() {
   await client.query("SET timezone = 'UTC'");
   return client;
 }
-
-export { query, getNewClient };

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,9 +1,3 @@
-/*
- * INFRASTRUCTURE LAYER: Database Client
- * This module follows the official 'node-postgres' one-shot client pattern.
- * In MVC, this provides the interface between Models and the PostgreSQL driver.
- */
-
 import { Client } from "pg";
 import { ServiceError } from "infra/errors";
 

--- a/infra/scripts/cleanup-next-dev-ports.js
+++ b/infra/scripts/cleanup-next-dev-ports.js
@@ -1,0 +1,101 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+module.exports = {
+  cleanupNextDevPorts,
+};
+
+const PORTS_TO_CLEAN = [3000, 3001, 3002, 3003, 3004];
+const projectRoot = path.resolve(__dirname, "..", "..");
+
+if (require.main === module) {
+  cleanupNextDevPorts();
+}
+
+function cleanupNextDevPorts() {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  cleanupBySs();
+  cleanupByLsof();
+}
+
+function cleanupBySs() {
+  const ssResult = spawnSync("ss", ["-ltnp"], {
+    encoding: "utf8",
+  });
+
+  if (ssResult.status !== 0 || !ssResult.stdout) {
+    return;
+  }
+
+  const pids = new Set();
+  const lines = ssResult.stdout.split("\n");
+
+  for (const line of lines) {
+    if (!PORTS_TO_CLEAN.some((port) => line.includes(`:${port}`))) {
+      continue;
+    }
+
+    const pidMatches = line.matchAll(/pid=(\d+)/g);
+    for (const match of pidMatches) {
+      pids.add(Number.parseInt(match[1], 10));
+    }
+  }
+
+  for (const pid of pids) {
+    terminateIfNextProcess(pid);
+  }
+}
+
+function cleanupByLsof() {
+  for (const port of PORTS_TO_CLEAN) {
+    const lsofResult = spawnSync("lsof", ["-ti", `tcp:${port}`], {
+      encoding: "utf8",
+    });
+
+    if (lsofResult.status !== 0 || !lsofResult.stdout) {
+      continue;
+    }
+
+    const pids = lsofResult.stdout
+      .trim()
+      .split("\n")
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => Number.isInteger(value));
+
+    for (const pid of pids) {
+      terminateIfNextProcess(pid);
+    }
+  }
+}
+
+function terminateIfNextProcess(pid) {
+  const psResult = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+    encoding: "utf8",
+  });
+  const command = psResult.stdout?.trim() ?? "";
+  const processCwd = getProcessCwd(pid);
+
+  if (!command.includes("next") || !processCwd?.startsWith(projectRoot)) {
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    if (error.code !== "ESRCH") {
+      throw error;
+    }
+  }
+}
+
+function getProcessCwd(pid) {
+  try {
+    return fs.readlinkSync(`/proc/${pid}/cwd`);
+  } catch {
+    return null;
+  }
+}

--- a/infra/scripts/cleanup-next-dev-ports.js
+++ b/infra/scripts/cleanup-next-dev-ports.js
@@ -1,3 +1,4 @@
+/* global Set */
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");

--- a/infra/scripts/next-watch-pid.js
+++ b/infra/scripts/next-watch-pid.js
@@ -1,10 +1,10 @@
 const os = require("node:os");
 const path = require("node:path");
 
-function getNextWatchPidFilePath() {
-  return path.join(os.tmpdir(), "automanews-next-test-watch.pid");
-}
-
 module.exports = {
   getNextWatchPidFilePath,
 };
+
+function getNextWatchPidFilePath() {
+  return path.join(os.tmpdir(), "automanews-next-test-watch.pid");
+}

--- a/infra/scripts/next-watch-pid.js
+++ b/infra/scripts/next-watch-pid.js
@@ -1,0 +1,10 @@
+const os = require("node:os");
+const path = require("node:path");
+
+function getNextWatchPidFilePath() {
+  return path.join(os.tmpdir(), "automanews-next-test-watch.pid");
+}
+
+module.exports = {
+  getNextWatchPidFilePath,
+};

--- a/infra/scripts/open-next-watch-server.js
+++ b/infra/scripts/open-next-watch-server.js
@@ -1,4 +1,5 @@
-const { execFileSync, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const { execFileSync, spawn, spawnSync } = require("node:child_process");
 const path = require("node:path");
 
 const projectRoot = path.resolve(__dirname, "..", "..");
@@ -76,6 +77,11 @@ function openOnWindows() {
 }
 
 function openOnLinux() {
+  if (isWsl()) {
+    spawnDetachedRunner();
+    return;
+  }
+
   const command = buildPosixCommand();
   const escapedCommand = escapeSingleQuotes(command);
   const terminalLaunchers = [
@@ -98,6 +104,24 @@ function openOnLinux() {
   throw new Error(
     "No supported Linux terminal emulator found. Tried gnome-terminal, konsole, xfce4-terminal, x-terminal-emulator, and xterm.",
   );
+}
+
+function isWsl() {
+  try {
+    const version = fs.readFileSync("/proc/version", "utf8").toLowerCase();
+    return version.includes("microsoft") || version.includes("wsl");
+  } catch {
+    return false;
+  }
+}
+
+function spawnDetachedRunner() {
+  const child = spawn(process.execPath, [runnerPath], {
+    cwd: projectRoot,
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
 }
 
 function buildPosixCommand() {

--- a/infra/scripts/run-next-watch-server.js
+++ b/infra/scripts/run-next-watch-server.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawn, spawnSync } = require("node:child_process");
+const { cleanupNextDevPorts } = require("./cleanup-next-dev-ports.js");
 const { getNextWatchPidFilePath } = require("./next-watch-pid.js");
 
 const projectRoot = path.resolve(__dirname, "..", "..");
@@ -20,14 +21,19 @@ process.on("exit", cleanup);
 async function main() {
   process.chdir(projectRoot);
   fs.rmSync(pidFile, { force: true });
+  cleanupNextDevPorts();
 
   runNpmScript("services:wait:db");
   runNpmScript("migrations:up");
 
-  nextProcess = spawn(getNpxCommand(), ["next", "dev"], {
-    cwd: projectRoot,
-    stdio: "inherit",
-  });
+  nextProcess = spawn(
+    getNpxCommand(),
+    ["next", "dev", "--hostname", "127.0.0.1", "--port", "3000"],
+    {
+      cwd: projectRoot,
+      stdio: "inherit",
+    },
+  );
 
   fs.writeFileSync(pidFile, String(nextProcess.pid));
 

--- a/infra/scripts/run-next-watch-server.js
+++ b/infra/scripts/run-next-watch-server.js
@@ -1,9 +1,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawn, spawnSync } = require("node:child_process");
+const { getNextWatchPidFilePath } = require("./next-watch-pid");
 
 const projectRoot = path.resolve(__dirname, "..", "..");
-const pidFile = path.join(projectRoot, ".next-test-watch.pid");
+const pidFile = getNextWatchPidFilePath();
 
 let nextProcess;
 

--- a/infra/scripts/run-next-watch-server.js
+++ b/infra/scripts/run-next-watch-server.js
@@ -13,6 +13,10 @@ main().catch((error) => {
   process.exit(1);
 });
 
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("exit", cleanup);
+
 async function main() {
   process.chdir(projectRoot);
   fs.rmSync(pidFile, { force: true });
@@ -63,7 +67,3 @@ function getNpmCommand() {
 function getNpxCommand() {
   return process.platform === "win32" ? "npx.cmd" : "npx";
 }
-
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-process.on("exit", cleanup);

--- a/infra/scripts/run-next-watch-server.js
+++ b/infra/scripts/run-next-watch-server.js
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { spawn, spawnSync } = require("node:child_process");
-const { getNextWatchPidFilePath } = require("./next-watch-pid");
+const { getNextWatchPidFilePath } = require("./next-watch-pid.js");
 
 const projectRoot = path.resolve(__dirname, "..", "..");
 const pidFile = getNextWatchPidFilePath();

--- a/infra/scripts/stop-next-watch-server.js
+++ b/infra/scripts/stop-next-watch-server.js
@@ -1,5 +1,5 @@
 const fs = require("node:fs");
-const { getNextWatchPidFilePath } = require("./next-watch-pid");
+const { getNextWatchPidFilePath } = require("./next-watch-pid.js");
 
 const pidFile = getNextWatchPidFilePath();
 

--- a/infra/scripts/stop-next-watch-server.js
+++ b/infra/scripts/stop-next-watch-server.js
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
-const path = require("node:path");
+const { getNextWatchPidFilePath } = require("./next-watch-pid");
 
-const pidFile = path.resolve(__dirname, "..", "..", ".next-test-watch.pid");
+const pidFile = getNextWatchPidFilePath();
 
 if (!fs.existsSync(pidFile)) {
   process.exit(0);

--- a/infra/scripts/wait-for-next-dev.js
+++ b/infra/scripts/wait-for-next-dev.js
@@ -1,0 +1,73 @@
+/**
+ * Waits until `next dev` serves JSON from the API routes integration tests use.
+ * `wait-on` against /api/v1/status alone is not enough: Next compiles other routes
+ * on first request; until then dynamic routes can return HTML error pages.
+ */
+const baseUrl = process.env.TEST_BASE_URL ?? "http://127.0.0.1:3000";
+const timeoutMs = Number(process.env.WAIT_FOR_NEXT_MS ?? 120_000);
+const intervalMs = Number(process.env.WAIT_FOR_NEXT_INTERVAL_MS ?? 400);
+
+const probeUsername = "__integration_probe_nonexistent_user__";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isJsonResponse(response) {
+  const ct = response.headers.get("content-type") || "";
+  return ct.includes("application/json");
+}
+
+async function assertNextApiReady() {
+  const statusRes = await fetch(`${baseUrl}/api/v1/status`);
+  if (statusRes.status !== 200 || !isJsonResponse(statusRes)) {
+    throw new Error(
+      `status: want 200+json, got ${statusRes.status} content-type=${statusRes.headers.get("content-type")}`,
+    );
+  }
+
+  const userRes = await fetch(`${baseUrl}/api/v1/users/${probeUsername}`);
+  if (userRes.status !== 404 || !isJsonResponse(userRes)) {
+    throw new Error(
+      `users/[username]: want 404+json, got ${userRes.status} content-type=${userRes.headers.get("content-type")}`,
+    );
+  }
+
+  const usersIndexRes = await fetch(`${baseUrl}/api/v1/users`);
+  if (
+    (usersIndexRes.status !== 405 && usersIndexRes.status !== 404) ||
+    !isJsonResponse(usersIndexRes)
+  ) {
+    throw new Error(
+      `users index: want 404/405+json, got ${usersIndexRes.status} content-type=${usersIndexRes.headers.get("content-type")}`,
+    );
+  }
+
+  const migrationsRes = await fetch(`${baseUrl}/api/v1/migrations`);
+  if (migrationsRes.status !== 200 || !isJsonResponse(migrationsRes)) {
+    throw new Error(
+      `migrations: want 200+json, got ${migrationsRes.status} content-type=${migrationsRes.headers.get("content-type")}`,
+    );
+  }
+}
+
+async function main() {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      await assertNextApiReady();
+      console.log("Next.js dev API routes ready for integration tests.");
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(intervalMs);
+    }
+  }
+
+  console.error("Timed out waiting for Next.js dev server.", lastError);
+  process.exit(1);
+}
+
+main();

--- a/infra/scripts/wait-for-next-dev.js
+++ b/infra/scripts/wait-for-next-dev.js
@@ -1,3 +1,4 @@
+/* global Promise */
 /**
  * Waits until `next dev` serves JSON from the API routes integration tests use.
  * `wait-on` against /api/v1/status alone is not enough: Next compiles other routes

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,5 +1,8 @@
 const { exec } = require("node:child_process");
 
+console.log("\n\n⭕ Aguardando Postgres aceitar conexões...\n");
+checkPostgres();
+
 function checkPostgres() {
   exec(
     "docker exec local_postgres pg_isready --host localhost",
@@ -14,6 +17,3 @@ function checkPostgres() {
     },
   );
 }
-
-console.log("\n\n⭕ Aguardando Postgres aceitar conexões...\n");
-checkPostgres();

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -1,7 +1,7 @@
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
-import { getNewClient } from "infra/database";
-import { ServiceError } from "infra/errors";
+import { getNewClient } from "infra/database.js";
+import { ServiceError } from "infra/errors.js";
 
 function defaultMigrationsOptions(dbClient, overrides = {}) {
   return {

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -3,6 +3,8 @@ import { resolve } from "node:path";
 import { getNewClient } from "infra/database.js";
 import { ServiceError } from "infra/errors.js";
 
+export { listPendingMigrations, runPendingMigrations };
+
 function defaultMigrationsOptions(dbClient, overrides = {}) {
   return {
     dryRun: true,
@@ -55,5 +57,3 @@ async function runPendingMigrations() {
     await dbClient?.end();
   }
 }
-
-export { listPendingMigrations, runPendingMigrations };

--- a/models/password.js
+++ b/models/password.js
@@ -1,5 +1,7 @@
 import { hash, compare } from "bcryptjs";
 
+export { comparePassword, hashObjectPassword };
+
 async function hashPassword(password) {
   const saltRounds = process.env.NODE_ENV === "production" ? 14 : 1;
   return await hash(password, saltRounds);
@@ -14,5 +16,3 @@ async function hashObjectPassword(object) {
     password: await hashPassword(object.password),
   });
 }
-
-export { comparePassword, hashObjectPassword };

--- a/models/status.js
+++ b/models/status.js
@@ -1,5 +1,5 @@
-import { query } from "infra/database";
-import { ServiceError } from "infra/errors";
+import { query } from "infra/database.js";
+import { ServiceError } from "infra/errors.js";
 
 async function getSystemStatus() {
   const updatedAt = new Date().toISOString();

--- a/models/status.js
+++ b/models/status.js
@@ -9,7 +9,13 @@ async function getSystemStatus() {
   const dbMaxConnectionsValue = await getDbMaxConnections();
   const dbOpenedConnectionsValue = await getDbOpenedConnections();
 
-  if (!dbVersionValue || !dbMaxConnectionsValue || !dbOpenedConnectionsValue) {
+  if (
+    !dbVersionValue ||
+    dbMaxConnectionsValue == null ||
+    Number.isNaN(dbMaxConnectionsValue) ||
+    dbOpenedConnectionsValue == null ||
+    Number.isNaN(dbOpenedConnectionsValue)
+  ) {
     throw new ServiceError({
       cause: new Error("Failed to get database status."),
       message: "Não foi possível obter o status do banco de dados.",

--- a/models/status.js
+++ b/models/status.js
@@ -1,6 +1,8 @@
 import { query } from "infra/database.js";
 import { ServiceError } from "infra/errors.js";
 
+export { getSystemStatus };
+
 async function getSystemStatus() {
   const updatedAt = new Date().toISOString();
   const dbVersionValue = await getDbVersion();
@@ -53,5 +55,3 @@ async function getDbOpenedConnections() {
   });
   return parseInt(dbOpenedConnectionsResult.rows[0].opened_connections);
 }
-
-export { getSystemStatus };

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,5 @@
-import { query } from "infra/database";
-import { ValidationError, NotFoundError } from "infra/errors";
+import { query } from "infra/database.js";
+import { ValidationError, NotFoundError } from "infra/errors.js";
 import { hashObjectPassword } from "models/password";
 
 export { createUser, getUserByUsername, updateUser };

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "dev": "npm run services:up &&  npm run services:wait:db && npm run migrations:up && next dev",
     "postdev": "npm run services:stop",
-    "test": "npm run services:up && concurrently -n next,jest --hide next -k -s command-jest \"next dev\" \"jest --runInBand --verbose\"",
+    "test": "node infra/scripts/cleanup-next-dev-ports.js && npm run services:up && npm run services:wait:db && npm run migrations:up && concurrently -n next,jest --hide next -k -s command-jest \"next dev --hostname 127.0.0.1 --port 3000\" \"node infra/scripts/wait-for-next-dev.js && npx jest --runInBand --verbose\"",
     "posttest": "npm run services:stop",
     "test:watch:server": "node infra/scripts/open-next-watch-server.js",
     "test:watch:server:stop": "node infra/scripts/stop-next-watch-server.js",
-    "test:watch": "npm run services:up && npm run test:watch:server && jest --runInBand --watchAll --verbose",
+    "test:watch": "node infra/scripts/cleanup-next-dev-ports.js && npm run services:up && npm run test:watch:server && node infra/scripts/wait-for-next-dev.js && npx jest --runInBand --watchAll --verbose",
     "posttest:watch": "npm run test:watch:server:stop && npm run services:stop",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,5 +1,8 @@
-import { listPendingMigrations, runPendingMigrations } from "models/migrator";
-import { exceptionHandlers } from "infra/controller";
+import {
+  listPendingMigrations,
+  runPendingMigrations,
+} from "models/migrator.js";
+import { exceptionHandlers } from "infra/controller.js";
 import { createRouter } from "next-connect";
 
 const router = createRouter();

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,6 +1,6 @@
-import { exceptionHandlers } from "infra/controller";
+import { exceptionHandlers } from "infra/controller.js";
 import { createRouter } from "next-connect";
-import { getSystemStatus } from "models/status";
+import { getSystemStatus } from "models/status.js";
 
 const router = createRouter();
 

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,6 +1,6 @@
-import { exceptionHandlers } from "infra/controller";
+import { exceptionHandlers } from "infra/controller.js";
 import { createRouter } from "next-connect";
-import { getUserByUsername, updateUser } from "models/user";
+import { getUserByUsername, updateUser } from "models/user.js";
 
 const router = createRouter();
 

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,6 +1,6 @@
-import { exceptionHandlers } from "infra/controller";
+import { exceptionHandlers } from "infra/controller.js";
 import { createRouter } from "next-connect";
-import { createUser } from "models/user";
+import { createUser } from "models/user.js";
 
 const router = createRouter();
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,4 @@
-// pages/index.js
-
-function Home() {
+export default function Home() {
   return (
     <>
       <div className="page">
@@ -295,5 +293,3 @@ function Home() {
     </>
   );
 }
-
-export default Home; // <- obrigatório no Pages Router

--- a/pages/status/index.js
+++ b/pages/status/index.js
@@ -1,31 +1,6 @@
 import useSWR from "swr";
 import { useState, useEffect } from "react";
 
-async function fetchAPI(key) {
-  const response = await fetch(key);
-  const responseBody = await response.json();
-  return responseBody;
-}
-
-function useTheme() {
-  const [dark, setDark] = useState(false);
-
-  useEffect(() => {
-    const saved = localStorage.getItem("status-theme");
-    if (saved === "dark") setDark(true);
-  }, []);
-
-  function toggle() {
-    setDark((prev) => {
-      const next = !prev;
-      localStorage.setItem("status-theme", next ? "dark" : "light");
-      return next;
-    });
-  }
-
-  return { dark, toggle };
-}
-
 export default function StatusPage() {
   const { dark, toggle } = useTheme();
 
@@ -147,6 +122,12 @@ export default function StatusPage() {
   );
 }
 
+async function fetchAPI(key) {
+  const response = await fetch(key);
+  const responseBody = await response.json();
+  return responseBody;
+}
+
 function UpdatedAt() {
   const { data, isLoading } = useSWR("/api/v1/status", fetchAPI);
 
@@ -180,4 +161,23 @@ function DbStatus() {
       </ul>
     </div>
   );
+}
+
+function useTheme() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("status-theme");
+    if (saved === "dark") setDark(true);
+  }, []);
+
+  function toggle() {
+    setDark((prev) => {
+      const next = !prev;
+      localStorage.setItem("status-theme", next ? "dark" : "light");
+      return next;
+    });
+  }
+
+  return { dark, toggle };
 }

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,4 +1,8 @@
-import { waitForAllServices, clearDatabase } from "tests/orchestrator.js";
+import {
+  waitForAllServices,
+  clearDatabase,
+  testBaseUrl,
+} from "tests/orchestrator.js";
 
 describe("GET /api/v1/migrations", () => {
   describe("Anonymous user", () => {
@@ -7,7 +11,7 @@ describe("GET /api/v1/migrations", () => {
       await clearDatabase();
     });
     test("Check migrations contents", async () => {
-      const response = await fetch("http://localhost:3000/api/v1/migrations");
+      const response = await fetch(`${testBaseUrl}/api/v1/migrations`);
 
       expect(response.status).toBe(200);
 

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -13,12 +13,9 @@ describe("POST /api/v1/migrations", () => {
   describe("Anonymous user", () => {
     describe("Running pending migrations", () => {
       test("All migrations are run successfully and returned the correct data", async () => {
-        const response1 = await fetch(
-          `${testBaseUrl}/api/v1/migrations`,
-          {
-            method: "POST",
-          },
-        );
+        const response1 = await fetch(`${testBaseUrl}/api/v1/migrations`, {
+          method: "POST",
+        });
 
         expect(response1.status).toBe(201);
 
@@ -28,12 +25,9 @@ describe("POST /api/v1/migrations", () => {
         expect(response1Body.length).toBeGreaterThan(0);
       });
       test("No more migrations to run", async () => {
-        const response2 = await fetch(
-          `${testBaseUrl}/api/v1/migrations`,
-          {
-            method: "POST",
-          },
-        );
+        const response2 = await fetch(`${testBaseUrl}/api/v1/migrations`, {
+          method: "POST",
+        });
 
         expect(response2.status).toBe(200);
 

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -1,4 +1,8 @@
-import { waitForAllServices, clearDatabase } from "tests/orchestrator.js";
+import {
+  waitForAllServices,
+  clearDatabase,
+  testBaseUrl,
+} from "tests/orchestrator.js";
 
 beforeAll(async () => {
   await waitForAllServices();
@@ -10,7 +14,7 @@ describe("POST /api/v1/migrations", () => {
     describe("Running pending migrations", () => {
       test("All migrations are run successfully and returned the correct data", async () => {
         const response1 = await fetch(
-          "http://localhost:3000/api/v1/migrations",
+          `${testBaseUrl}/api/v1/migrations`,
           {
             method: "POST",
           },
@@ -25,7 +29,7 @@ describe("POST /api/v1/migrations", () => {
       });
       test("No more migrations to run", async () => {
         const response2 = await fetch(
-          "http://localhost:3000/api/v1/migrations",
+          `${testBaseUrl}/api/v1/migrations`,
           {
             method: "POST",
           },

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,4 +1,4 @@
-import { waitForAllServices } from "tests/orchestrator.js";
+import { waitForAllServices, testBaseUrl } from "tests/orchestrator.js";
 
 // Parse numeric values to match the API's integer output
 const expectedDbVersion = process.env.POSTGRES_VERSION;
@@ -13,7 +13,7 @@ describe("GET /api/v1/status", () => {
     // Fetches data once before running the individual test assertions
     beforeAll(async () => {
       await waitForAllServices();
-      response = await fetch("http://localhost:3000/api/v1/status");
+      response = await fetch(`${testBaseUrl}/api/v1/status`);
       responseBody = await response.json();
     });
 

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,4 +1,4 @@
-import { waitForAllServices } from "tests/orchestrator.js";
+import { waitForAllServices, testBaseUrl } from "tests/orchestrator.js";
 
 describe("POST /api/v1/status", () => {
   describe("Anonymous user", () => {
@@ -7,7 +7,7 @@ describe("POST /api/v1/status", () => {
     // Fetches data once before running the individual test assertions
     beforeAll(async () => {
       await waitForAllServices();
-      response = await fetch("http://localhost:3000/api/v1/status", {
+      response = await fetch(`${testBaseUrl}/api/v1/status`, {
         method: "POST",
       });
     });

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -2,6 +2,7 @@ import {
   waitForAllServices,
   clearDatabase,
   createDummyUser,
+  testBaseUrl,
 } from "tests/orchestrator.js";
 import { runPendingMigrations } from "models/migrator.js";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
@@ -25,7 +26,7 @@ describe("GET /api/v1/users/[username]", () => {
         const { username } = dummyUser;
 
         const response = await fetch(
-          `http://localhost:3000/api/v1/users/${username}`,
+          `${testBaseUrl}/api/v1/users/${username}`,
         );
 
         const responseBody = await response.json();
@@ -41,7 +42,7 @@ describe("GET /api/v1/users/[username]", () => {
       test("'DUMMY_USER' is retrieved successfully and returned the correct data", async () => {
         const uppercaseUsername = dummyUser.username.toUpperCase();
         const response = await fetch(
-          `http://localhost:3000/api/v1/users/${uppercaseUsername}`,
+          `${testBaseUrl}/api/v1/users/${uppercaseUsername}`,
         );
 
         const responseBody = await response.json();
@@ -57,7 +58,7 @@ describe("GET /api/v1/users/[username]", () => {
       test("'non_existent_user' returns 404 Not Found", async () => {
         const nonExistentUsername = "non_existent_user";
         const response = await fetch(
-          `http://localhost:3000/api/v1/users/${nonExistentUsername}`,
+          `${testBaseUrl}/api/v1/users/${nonExistentUsername}`,
         );
 
         expect(response.status).toBe(404);

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -25,9 +25,7 @@ describe("GET /api/v1/users/[username]", () => {
       test("'dummy_user' is retrieved successfully and returned the correct data", async () => {
         const { username } = dummyUser;
 
-        const response = await fetch(
-          `${testBaseUrl}/api/v1/users/${username}`,
-        );
+        const response = await fetch(`${testBaseUrl}/api/v1/users/${username}`);
 
         const responseBody = await response.json();
 

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -3,7 +3,7 @@ import {
   clearDatabase,
   createDummyUser,
 } from "tests/orchestrator.js";
-import { runPendingMigrations } from "models/migrator";
+import { runPendingMigrations } from "models/migrator.js";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -4,7 +4,7 @@ import {
   createDummyUser,
   getUser,
 } from "tests/orchestrator.js";
-import { runPendingMigrations } from "models/migrator";
+import { runPendingMigrations } from "models/migrator.js";
 import { comparePassword } from "models/password";
 
 beforeAll(async () => {

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -3,6 +3,7 @@ import {
   clearDatabase,
   createDummyUser,
   getUser,
+  testBaseUrl,
 } from "tests/orchestrator.js";
 import { runPendingMigrations } from "models/migrator.js";
 import { comparePassword } from "models/password";
@@ -18,7 +19,7 @@ beforeEach(async () => {
 
 async function patchUser(username, userInputValues) {
   const response = await fetch(
-    `http://localhost:3000/api/v1/users/${username}`,
+    `${testBaseUrl}/api/v1/users/${username}`,
     {
       method: "PATCH",
       headers: {

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -18,16 +18,13 @@ beforeEach(async () => {
 });
 
 async function patchUser(username, userInputValues) {
-  const response = await fetch(
-    `${testBaseUrl}/api/v1/users/${username}`,
-    {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(userInputValues),
+  const response = await fetch(`${testBaseUrl}/api/v1/users/${username}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
     },
-  );
+    body: JSON.stringify(userInputValues),
+  });
 
   const responseBody = await response.json();
 

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -5,7 +5,7 @@ import {
   postUser,
   getUser,
 } from "tests/orchestrator.js";
-import { runPendingMigrations } from "models/migrator";
+import { runPendingMigrations } from "models/migrator.js";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
 import { comparePassword } from "models/password";
 

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -3,8 +3,7 @@ import { query } from "infra/database";
 import { createUser, getUserByUsername } from "models/user";
 
 /** Use 127.0.0.1 so probes match `wait-for-next-dev.js` and avoid IPv6/localhost quirks on Linux. */
-export const testBaseUrl =
-  process.env.TEST_BASE_URL ?? "http://127.0.0.1:3000";
+export const testBaseUrl = process.env.TEST_BASE_URL ?? "http://127.0.0.1:3000";
 
 export {
   waitForAllServices,

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -2,6 +2,10 @@ import retry from "async-retry";
 import { query } from "infra/database";
 import { createUser, getUserByUsername } from "models/user";
 
+/** Use 127.0.0.1 so probes match `wait-for-next-dev.js` and avoid IPv6/localhost quirks on Linux. */
+export const testBaseUrl =
+  process.env.TEST_BASE_URL ?? "http://127.0.0.1:3000";
+
 export {
   waitForAllServices,
   clearDatabase,
@@ -10,24 +14,31 @@ export {
   getUser,
 };
 
+function isJsonResponse(response) {
+  const ct = response.headers.get("content-type") || "";
+  return ct.includes("application/json");
+}
+
 async function waitForAllServices() {
   return await waitForWebServer();
 
   async function waitForWebServer() {
-    return retry(fetchStatusPage, {
-      retries: 10,
-      maxTimeout: 1000,
+    return retry(assertStatusJsonOk, {
+      retries: 30,
+      maxTimeout: 1500,
       onRetry: (error, attempt) => {
         console.log(
-          `Attempt ${attempt} failed to fetch status page. Error: ${error.message}`,
+          `Attempt ${attempt} failed waiting for Next.js API. Error: ${error.message}`,
         );
       },
     });
 
-    async function fetchStatusPage() {
-      const response = await fetch("http://localhost:3000/api/v1/status");
-      if (response.status !== 200) {
-        throw new Error(`Expected status 200 but received ${response.status}`);
+    async function assertStatusJsonOk() {
+      const statusRes = await fetch(`${testBaseUrl}/api/v1/status`);
+      if (statusRes.status !== 200 || !isJsonResponse(statusRes)) {
+        throw new Error(
+          `status: want 200+json, got ${statusRes.status} content-type=${statusRes.headers.get("content-type")}`,
+        );
       }
     }
   }
@@ -58,7 +69,7 @@ async function createDummyUser(overrides = {}) {
 }
 
 async function postUser(userInput) {
-  const response = await fetch("http://localhost:3000/api/v1/users", {
+  const response = await fetch(`${testBaseUrl}/api/v1/users`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -2,6 +2,14 @@ import retry from "async-retry";
 import { query } from "infra/database";
 import { createUser, getUserByUsername } from "models/user";
 
+export {
+  waitForAllServices,
+  clearDatabase,
+  createDummyUser,
+  postUser,
+  getUser,
+};
+
 async function waitForAllServices() {
   return await waitForWebServer();
 
@@ -70,11 +78,3 @@ async function getUser(username) {
   const user = await getUserByUsername(username);
   return serializeUser(user);
 }
-
-export {
-  waitForAllServices,
-  clearDatabase,
-  createDummyUser,
-  postUser,
-  getUser,
-};


### PR DESCRIPTION
## Why

After moving development to WSL/Ubuntu, local `test` and `test:watch` runs became flaky due to:
- stale Next.js dev processes occupying test ports
- startup race conditions between Next.js route readiness and Jest execution
- host/port inconsistencies (`localhost` resolution differences across environments)

This PR makes the test startup deterministic while preserving behavior in macOS and CI.

## What changed

- hardens `npm test` and `npm run test:watch` startup flow
  - ensures database is up and migrations are applied before running tests
  - waits for Next.js API readiness before starting Jest
  - uses `npx jest` for reliable binary resolution
- adds `infra/scripts/wait-for-next-dev.js`
  - validates API endpoints are returning JSON and expected status codes before tests run
- adds `infra/scripts/cleanup-next-dev-ports.js`
  - cleans stale Next.js dev processes on test-related ports for this project only
- updates watch server runner to use consistent host/port and cleanup behavior
- standardizes integration test base URL through `tests/orchestrator.js` (`testBaseUrl`)
- fixes status validation logic so `opened_connections = 0` is treated as valid

## Result

- `npm test` is now stable in WSL/Ubuntu
- integration suite passes consistently (`7/7` suites, `19/19` tests)
- no ESLint issues introduced

## Notes

- this PR is scoped to infra/test workflow stability and does not change auth feature behavior
- branch remains compatible with existing macOS/CI flows while addressing Linux-specific startup timing issues